### PR TITLE
Response error renaming in request node

### DIFF
--- a/nodes/dxl-request.html
+++ b/nodes/dxl-request.html
@@ -65,6 +65,10 @@
         <dd> <a href="https://opendxl.github.io/opendxl-client-javascript/jsdoc/Response.html" target="_blank">Response</a> or <a href="https://opendxl.github.io/opendxl-client-javascript/jsdoc/ErrorResponse.html" target="_blank">ErrorResponse</a> object received from the DXL client for the request message.</dd>
         <dt>dxlMessage <span class="property-type">dxl-client.Message</d></span></dt>
         <dd> <a href="https://opendxl.github.io/opendxl-client-javascript/jsdoc/Response.html" target="_blank">Response</a> or <a href="https://opendxl.github.io/opendxl-client-javascript/jsdoc/ErrorResponse.html" target="_blank">ErrorResponse</a> object received from the DXL client for the request message.</dd>
+        <dt class="optional">dxlError <span class="property-type">string</span></dt>
+        <dd> If the error returned from the broker contains a DXL <a href="https://opendxl.github.io/opendxl-client-javascript/jsdoc/ErrorResponse.html" target="_blank">ErrorResponse message</a>, a <code>dxlError</code> object is added to the <code>msg</code>.
+        The <code>code</code> property on the <code>dxlError</code> is set to the numeric <a href="https://opendxl.github.io/opendxl-client-javascript/jsdoc/ErrorResponse.html#errorCode" target="_blank">errorCode</a> from the ErrorResponse or, if the code is a common DXL error code, a string representation of the code.
+        For a list of the well-known DXL response error code strings, see the list of constants in the <a href="https://opendxl.github.io/opendxl-client-javascript/jsdoc/module-ResponseErrorCode.html" target="_blank">ResponseErrorCode</a> module.</dd>
     </dl>
     <p>The <code>dxlTopic</code> property is removed, if present, from the output message.</p>
     <h3>Node Properties</h3>

--- a/nodes/dxl-request.js
+++ b/nodes/dxl-request.js
@@ -70,10 +70,14 @@ module.exports = function (RED) {
             this._client.asyncRequest(request,
               function (error, response) {
                 if (error) {
-                  if (error instanceof dxl.MessageError) {
-                    msg.dxlError = {code: error.code}
-                    msg.payload = error.detail.payload
-                    msg.dxlResponse = error.detail
+                  msg.dxlError = {code: error.code}
+                  if (error.dxlErrorResponse) {
+                    var responseMessage = error.dxlErrorResponse
+                    if (!error.code) {
+                      msg.dxlError.code = responseMessage.errorCode
+                    }
+                    msg.payload = responseMessage.payload
+                    msg.dxlResponse = responseMessage
                     msg.dxlMessage = msg.dxlResponse
                   }
                   node.error(error.message, msg)


### PR DESCRIPTION
Previously, the `dxlError.code` property was always populated onto the flow message from the corresponding `code` property on the `MessageError` received in the response for a failed request. In later OpenDXL JavaScript client releases, the `MessageError` class (changed to `RequestError`) will always populate its `code` property as a string value and be empty for custom error codes.

This commit changes the logic for populating the `dxlError.code` property to use the string-based `code` if non-empty but otherwise falls back to the numeric `errorCode` in the `dxlErrorResponse` included in the `RequestError` instance.

This PR is dependent upon changes to the OpenDXL JavaScript client in https://github.com/opendxl/opendxl-client-javascript/pull/3 and npm installs a branch build of the JavaScript client package for Travis testing for now. The branch build pin should be removed and replaced with a bump to the minimum `@opendxl/dxl-client` dependency once the new release is available.