### PR TITLE
Use custom port when new provisioning operation performed

### DIFF
--- a/nodes/dxl-client.html
+++ b/nodes/dxl-client.html
@@ -56,7 +56,8 @@
               hostInfo: {
                 'hostname': $('#node-provision-input-hostname').val(),
                 'user': $('#node-provision-input-username').val(),
-                'password': $('#node-provision-input-password').val()
+                'password': $('#node-provision-input-password').val(),
+                'port': $('#node-provision-input-port').val()
               }
             },
             success: function (response) {


### PR DESCRIPTION
Previously, if a user specified a custom value for the 'port' field in a
new provisioning operation, the custom value was ignored and the default
port, 8883, was always used instead. With the changes in this commit,
the port specified by the user is now passed along properly for the
provisioning operation.